### PR TITLE
Disassemble start menu frame type selection dialog

### DIFF
--- a/constants/start_menu_constants.asm
+++ b/constants/start_menu_constants.asm
@@ -6,5 +6,5 @@
 	const START_SAVE ; 4
 	const START_OPTIONS ; 5
 	const START_EXIT ; 6
-	const START_TRAINER_GEAR ; 7
+	const START_SET_FRAME ; 7
 	const START_RESET ; 8

--- a/engine/menu/frame_type_dialog.asm
+++ b/engine/menu/frame_type_dialog.asm
@@ -1,0 +1,43 @@
+INCLUDE "constants.asm"
+
+SECTION "engine/menu/frame_type_dialog.asm", ROMX
+
+FrameTypeDialog:
+	ld hl, .MenuHeader
+	call LoadMenuHeader
+	ld a, [wActiveFrame]
+	inc a
+	ld [wMenuCursorBuffer], a
+	call VerticalMenu
+	jr c, .close
+	ld a, [wMenuCursorY]
+	dec a
+	ld [wActiveFrame], a
+	push de
+	ld de, 3 ; SFX_MENU
+	call PlaySFX
+	pop de
+	call LoadFontExtra
+	call WaitBGMap
+
+.close
+	call CloseWindow
+	ret
+
+.MenuHeader:
+	db MENU_BACKUP_TILES ; flags
+	menu_coords 0, 0, SCREEN_WIDTH / 2, SCREEN_HEIGHT - 1
+	dw .MenuData
+	db 1 ; default option
+
+.MenuData:
+	db STATICMENU_CURSOR ; flags
+	db 8 ; items
+	db "１ばんめ@"
+	db "２ばんめ@"
+	db "３ばんめ@"
+	db "４ばんめ@"
+	db "５ばんめ@"
+	db "６ばんめ@"
+	db "７ばんめ@"
+	db "８ばんめ@"

--- a/engine/menu/start_menu.asm
+++ b/engine/menu/start_menu.asm
@@ -94,7 +94,7 @@ StartMenuJumpTable:
 	dw StartMenu_Save
 	dw StartMenu_Settings
 	dw StartMenu_Exit
-	dw StartMenu_TrainerGear
+	dw StartMenu_SetFrame
 	dw StartMenu_Reset
 
 StartMenuItems:
@@ -173,8 +173,8 @@ StartMenu_Exit:
 	ld a, 1
 	ret
 
-StartMenu_TrainerGear:
-	callab TrainerGear
+StartMenu_SetFrame:
+	callab FrameTypeDialog
 	ld a, 0
 	ret
 

--- a/layout.link
+++ b/layout.link
@@ -937,6 +937,8 @@ ROMX $3e
 
 ROMX $3f
 	org $4000
+	org $4305
+	"engine/menu/frame_type_dialog.asm"
 	org $4362
 	"engine/menu/reset_dialog.asm"
 	org $4a57

--- a/shim.sym
+++ b/shim.sym
@@ -155,7 +155,6 @@
 3A:52FB CryHeaderPointers
 
 3F:40E9 InGameDebugMenu
-3F:4305 TrainerGear
 3F:4C24 Functionfcc24
 3F:4E3E Functionfce3e
 3F:5B66 Functionfdb66


### PR DESCRIPTION
Corrects start menu item erroneously labelled as "Trainer Gear"