### PR TITLE
Build Non-Debug Roms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,12 +44,18 @@ jobs:
         if: steps.cache-baseroms.outputs.cache-hit != 'true'
         run: |
           sudo apt-get install wget p7zip-full
+          wget -O gold-nondebug.7z 'https://tcrf.net/images/e/e9/Pok%C3%A9mon_Gold_-_Spaceworld_1997_Demo_%28NonDebug%29.7z'
+          wget -O silver-nondebug.7z 'https://tcrf.net/images/6/68/Pok%C3%A9mon_Silver_-_Spaceworld_1997_Demo_%28NonDebug%29.7z'
           wget -O gold-debug.7z 'https://tcrf.net/images/3/33/Pok%C3%A9mon_Gold_-_Spaceworld_1997_Demo_%28Debug%29.7z'
           wget -O silver-debug.7z 'https://tcrf.net/images/b/b2/Pok%C3%A9mon_Silver_-_Spaceworld_1997_Demo_%28Debug%29.7z'
+          7z e gold-nondebug.7z
+          mv P*\(NonDebug\).sgb baserom-gold.gb
+          7z e silver-nondebug.7z
+          mv P*\(NonDebug\).sgb baserom-silver.gb
           7z e gold-debug.7z
-          mv P*\(Debug\).sgb baserom-gold.gb
+          mv P*\(Debug\).sgb baserom-gold-debug.gb
           7z e silver-debug.7z
-          mv P*\(Debug\).sgb baserom-silver.gb
+          mv P*\(Debug\).sgb baserom-silver-debug.gb
           rm -f *.7z P*\(Header\ Fixed\).sgb
 
       - name: Compare

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ ROMS := pokegold-spaceworld.gb \
         pokesilver-spaceworld-debug.gb
 CORRECTEDROMS := $(ROMS:%.gb=%-correctheader.gb)
 
-GOLD_BASEROM := baserom-gold.gb
-GOLD_DEBUG_BASEROM := baserom-gold-debug.gb
-SILVER_BASEROM := baserom-silver.gb
+GOLD_BASEROM         := baserom-gold.gb
+GOLD_DEBUG_BASEROM   := baserom-gold-debug.gb
+SILVER_BASEROM       := baserom-silver.gb
 SILVER_DEBUG_BASEROM := baserom-silver-debug.gb
 
 DIRS := home engine data gfx audio maps scripts ram dumps garbage
@@ -17,12 +17,11 @@ BUILD := build
 rwildcard = $(foreach d, $(wildcard $1*), $(filter $(subst *, %, $2), $d) $(call rwildcard, $d/, $2))
 ASMFILES := $(call rwildcard, $(DIRS), *.asm) $(FILES)
 
-GOLD_OBJS := $(patsubst %.asm, $(BUILD)/%_gold.o, $(ASMFILES))
-
-GOLD_DEBUG_OBJS := $(patsubst %.asm, $(BUILD)/%_gold_debug.o, $(ASMFILES))
-SILVER_OBJS := $(patsubst %.asm, $(BUILD)/%_silver.o, $(ASMFILES))
-
+GOLD_OBJS         := $(patsubst %.asm, $(BUILD)/%_gold.o, $(ASMFILES))
+GOLD_DEBUG_OBJS   := $(patsubst %.asm, $(BUILD)/%_gold_debug.o, $(ASMFILES))
+SILVER_OBJS       := $(patsubst %.asm, $(BUILD)/%_silver.o, $(ASMFILES))
 SILVER_DEBUG_OBJS := $(patsubst %.asm, $(BUILD)/%_silver_debug.o, $(ASMFILES))
+
 
 ### Build tools
 
@@ -61,11 +60,11 @@ gold: pokegold-spaceworld.gb pokegold-spaceworld-correctheader.gb
 .PHONY: silver
 silver: pokesilver-spaceworld.gb pokesilver-spaceworld-correctheader.gb
 
-.PHONY: gold-debug
-gold: pokegold-spaceworld-debug.gb pokegold-spaceworld_debug-correctheader.gb
+.PHONY: gold_debug
+gold_debug: pokegold-spaceworld-debug.gb pokegold-spaceworld-debug-correctheader.gb
 
-.PHONY: silver-debug
-silver: pokesilver-spaceworld-debug.gb pokesilver-spaceworld-debug-correctheader.gb
+.PHONY: silver_debug
+silver_debug: pokesilver-spaceworld-debug.gb pokesilver-spaceworld-debug-correctheader.gb
 
 .PHONY: compare
 compare: $(ROMS) $(CORRECTEDROMS)
@@ -91,8 +90,8 @@ tidy:
 	       $(ROMS:.gb=.sym) $(CORRECTEDROMS:.gb=.sym) \
 	       $(ROMS:.gb=.map) $(CORRECTEDROMS:.gb=.map) \
 	       $(GOLD_OBJS) $(SILVER_OBJS) \
-		   $(GOLD_DEBUG_OBJS) $(SILVER_DEBUG_OBJS) \
-		   rgbdscheck.o
+	       $(GOLD_DEBUG_OBJS) $(SILVER_DEBUG_OBJS) \
+	       rgbdscheck.o
 
 # Visualize disassembly progress.
 .PHONY: coverage
@@ -142,7 +141,7 @@ pokesilver-spaceworld.gb: RGBFIXFLAGS += -f lh -k 01 -l 0x33 -m 0x03 -p 0 -r 3 -
 pokesilver-spaceworld.gb: layout.link $(SILVER_OBJS) | $(BASEROM)
 	$(RGBLINK) $(RGBLINKFLAGS) -l layout.link -n $(@:.gb=.sym) -m $(@:.gb=.map) -O $(SILVER_BASEROM) -o $@ $(filter-out $<, $^)
 	$(RGBFIX) $(RGBFIXFLAGS) $@
-	
+
 pokegold-spaceworld-debug.gb: RGBFIXFLAGS += -f lh -k 01 -l 0x33 -m 0x03 -p 0 -r 3 -t POKEMON2GOLD
 pokegold-spaceworld-debug.gb: layout.link $(GOLD_DEBUG_OBJS) | $(BASEROM)
 	$(RGBLINK) $(RGBLINKFLAGS) -l layout.link -n $(@:.gb=.sym) -m $(@:.gb=.map) -O $(GOLD_DEBUG_BASEROM) -o $@ $(filter-out $<, $^)
@@ -154,11 +153,11 @@ pokesilver-spaceworld-debug.gb: layout.link $(SILVER_DEBUG_OBJS) | $(BASEROM)
 	$(RGBFIX) $(RGBFIXFLAGS) $@
 
 baserom-gold.gb:
-	@echo "Please obtain a copy of Gold.sgb and put it in this directory as $@"
+	@echo "Please obtain a copy of Gold_nondebug.sgb and put it in this directory as $@"
 	@exit 1
 
 baserom-silver.gb:
-	@echo "Please obtain a copy of Silver.sgb and put it in this directory as $@"
+	@echo "Please obtain a copy of Silver_nondebug.sgb and put it in this directory as $@"
 	@exit 1
 
 baserom-gold-debug.gb:
@@ -178,11 +177,10 @@ include gfx/gfx.mk
 
 RGBASMFLAGS += -E -i $(BUILD)/
 
-$(GOLD_OBJS):   RGBASMFLAGS += -D _GOLD
-$(SILVER_OBJS): RGBASMFLAGS += -D _SILVER
+$(GOLD_OBJS):         RGBASMFLAGS += -D _GOLD
+$(SILVER_OBJS):       RGBASMFLAGS += -D _SILVER
 $(GOLD_DEBUG_OBJS):   RGBASMFLAGS += -D _GOLD -D _DEBUG
 $(SILVER_DEBUG_OBJS): RGBASMFLAGS += -D _SILVER -D _DEBUG
-
 
 $(BUILD)/%_gold.o: $(BUILD)/%.asm | $$(dir $$@) rgbdscheck.o
 	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
@@ -201,7 +199,7 @@ $(BUILD)/%_gold.d: %.asm | $$(dir $$@) tools/scan_includes
 
 $(BUILD)/%_silver.d: %.asm | $$(dir $$@) tools/scan_includes
 	@tools/scan_includes -b $(BUILD)/ -i $(BUILD)/ -i ./ -o $@ -t $(@:.d=.o) $<
-	
+
 $(BUILD)/%_gold_debug.o: $(BUILD)/%.asm | $$(dir $$@) rgbdscheck.o
 	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 ROMS := pokegold-spaceworld.gb \
-        pokesilver-spaceworld.gb
+        pokesilver-spaceworld.gb \
+        pokegold-spaceworld-debug.gb \
+        pokesilver-spaceworld-debug.gb
 CORRECTEDROMS := $(ROMS:%.gb=%-correctheader.gb)
 
 GOLD_BASEROM := baserom-gold.gb
+GOLD_DEBUG_BASEROM := baserom-gold-debug.gb
 SILVER_BASEROM := baserom-silver.gb
+SILVER_DEBUG_BASEROM := baserom-silver-debug.gb
 
 DIRS := home engine data gfx audio maps scripts ram dumps garbage
 FILES :=
@@ -15,8 +19,10 @@ ASMFILES := $(call rwildcard, $(DIRS), *.asm) $(FILES)
 
 GOLD_OBJS := $(patsubst %.asm, $(BUILD)/%_gold.o, $(ASMFILES))
 
+GOLD_DEBUG_OBJS := $(patsubst %.asm, $(BUILD)/%_gold_debug.o, $(ASMFILES))
 SILVER_OBJS := $(patsubst %.asm, $(BUILD)/%_silver.o, $(ASMFILES))
 
+SILVER_DEBUG_OBJS := $(patsubst %.asm, $(BUILD)/%_silver_debug.o, $(ASMFILES))
 
 ### Build tools
 
@@ -55,6 +61,12 @@ gold: pokegold-spaceworld.gb pokegold-spaceworld-correctheader.gb
 .PHONY: silver
 silver: pokesilver-spaceworld.gb pokesilver-spaceworld-correctheader.gb
 
+.PHONY: gold-debug
+gold: pokegold-spaceworld-debug.gb pokegold-spaceworld_debug-correctheader.gb
+
+.PHONY: silver-debug
+silver: pokesilver-spaceworld-debug.gb pokesilver-spaceworld-debug-correctheader.gb
+
 .PHONY: compare
 compare: $(ROMS) $(CORRECTEDROMS)
 	@$(SHA1) -c roms.sha1
@@ -78,7 +90,9 @@ tidy:
 	rm -rf $(ROMS) $(CORRECTEDROMS) \
 	       $(ROMS:.gb=.sym) $(CORRECTEDROMS:.gb=.sym) \
 	       $(ROMS:.gb=.map) $(CORRECTEDROMS:.gb=.map) \
-	       $(GOLD_OBJS) $(SILVER_OBJS) rgbdscheck.o
+	       $(GOLD_OBJS) $(SILVER_OBJS) \
+		   $(GOLD_DEBUG_OBJS) $(SILVER_DEBUG_OBJS) \
+		   rgbdscheck.o
 
 # Visualize disassembly progress.
 .PHONY: coverage
@@ -105,6 +119,18 @@ pokesilver-spaceworld-correctheader.gb: pokesilver-spaceworld.gb
 	cp $(<:.gb=.sym) $(@:.gb=.sym)
 	$(RGBFIX) $(RGBFIXFLAGS) $@
 
+pokegold-spaceworld-debug-correctheader.gb: RGBFIXFLAGS += -f hg -m 0x10 -Wno-overwrite
+pokegold-spaceworld-debug-correctheader.gb: pokegold-spaceworld-debug.gb
+	cp $< $@
+	cp $(<:.gb=.sym) $(@:.gb=.sym)
+	$(RGBFIX) $(RGBFIXFLAGS) $@
+
+pokesilver-spaceworld-debug-correctheader.gb: RGBFIXFLAGS += -f hg -m 0x10 -Wno-overwrite
+pokesilver-spaceworld-debug-correctheader.gb: pokesilver-spaceworld-debug.gb
+	cp $< $@
+	cp $(<:.gb=.sym) $(@:.gb=.sym)
+	$(RGBFIX) $(RGBFIXFLAGS) $@
+
 RGBLINKFLAGS += -d
 
 pokegold-spaceworld.gb: RGBFIXFLAGS += -f lh -k 01 -l 0x33 -m 0x03 -p 0 -r 3 -t POKEMON2GOLD
@@ -116,12 +142,30 @@ pokesilver-spaceworld.gb: RGBFIXFLAGS += -f lh -k 01 -l 0x33 -m 0x03 -p 0 -r 3 -
 pokesilver-spaceworld.gb: layout.link $(SILVER_OBJS) | $(BASEROM)
 	$(RGBLINK) $(RGBLINKFLAGS) -l layout.link -n $(@:.gb=.sym) -m $(@:.gb=.map) -O $(SILVER_BASEROM) -o $@ $(filter-out $<, $^)
 	$(RGBFIX) $(RGBFIXFLAGS) $@
+	
+pokegold-spaceworld-debug.gb: RGBFIXFLAGS += -f lh -k 01 -l 0x33 -m 0x03 -p 0 -r 3 -t POKEMON2GOLD
+pokegold-spaceworld-debug.gb: layout.link $(GOLD_DEBUG_OBJS) | $(BASEROM)
+	$(RGBLINK) $(RGBLINKFLAGS) -l layout.link -n $(@:.gb=.sym) -m $(@:.gb=.map) -O $(GOLD_DEBUG_BASEROM) -o $@ $(filter-out $<, $^)
+	$(RGBFIX) $(RGBFIXFLAGS) $@
+
+pokesilver-spaceworld-debug.gb: RGBFIXFLAGS += -f lh -k 01 -l 0x33 -m 0x03 -p 0 -r 3 -t POKEMON2SILVER
+pokesilver-spaceworld-debug.gb: layout.link $(SILVER_DEBUG_OBJS) | $(BASEROM)
+	$(RGBLINK) $(RGBLINKFLAGS) -l layout.link -n $(@:.gb=.sym) -m $(@:.gb=.map) -O $(SILVER_DEBUG_BASEROM) -o $@ $(filter-out $<, $^)
+	$(RGBFIX) $(RGBFIXFLAGS) $@
 
 baserom-gold.gb:
-	@echo "Please obtain a copy of Gold_debug.sgb and put it in this directory as $@"
+	@echo "Please obtain a copy of Gold.sgb and put it in this directory as $@"
 	@exit 1
 
 baserom-silver.gb:
+	@echo "Please obtain a copy of Silver.sgb and put it in this directory as $@"
+	@exit 1
+
+baserom-gold-debug.gb:
+	@echo "Please obtain a copy of Gold_debug.sgb and put it in this directory as $@"
+	@exit 1
+
+baserom-silver-debug.gb:
 	@echo "Please obtain a copy of Silver_debug.sgb and put it in this directory as $@"
 	@exit 1
 
@@ -136,6 +180,9 @@ RGBASMFLAGS += -E -i $(BUILD)/
 
 $(GOLD_OBJS):   RGBASMFLAGS += -D _GOLD
 $(SILVER_OBJS): RGBASMFLAGS += -D _SILVER
+$(GOLD_DEBUG_OBJS):   RGBASMFLAGS += -D _GOLD -D _DEBUG
+$(SILVER_DEBUG_OBJS): RGBASMFLAGS += -D _SILVER -D _DEBUG
+
 
 $(BUILD)/%_gold.o: $(BUILD)/%.asm | $$(dir $$@) rgbdscheck.o
 	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
@@ -153,6 +200,24 @@ $(BUILD)/%_gold.d: %.asm | $$(dir $$@) tools/scan_includes
 	@tools/scan_includes -b $(BUILD)/ -i $(BUILD)/ -i ./ -o $@ -t $(@:.d=.o) $<
 
 $(BUILD)/%_silver.d: %.asm | $$(dir $$@) tools/scan_includes
+	@tools/scan_includes -b $(BUILD)/ -i $(BUILD)/ -i ./ -o $@ -t $(@:.d=.o) $<
+	
+$(BUILD)/%_gold_debug.o: $(BUILD)/%.asm | $$(dir $$@) rgbdscheck.o
+	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
+
+$(BUILD)/%_gold_debug.o: %.asm | $$(dir $$@) rgbdscheck.o
+	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
+
+$(BUILD)/%_silver_debug.o: $(BUILD)/%.asm | $$(dir $$@) rgbdscheck.o
+	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
+
+$(BUILD)/%_silver_debug.o: %.asm | $$(dir $$@) rgbdscheck.o
+	$(RGBASM) $(RGBASMFLAGS) $(OUTPUT_OPTION) $<
+
+$(BUILD)/%_gold_debug.d: %.asm | $$(dir $$@) tools/scan_includes
+	@tools/scan_includes -b $(BUILD)/ -i $(BUILD)/ -i ./ -o $@ -t $(@:.d=.o) $<
+
+$(BUILD)/%_silver_debug.d: %.asm | $$(dir $$@) tools/scan_includes
 	@tools/scan_includes -b $(BUILD)/ -i $(BUILD)/ -i ./ -o $@ -t $(@:.d=.o) $<
 
 .PRECIOUS: $(BUILD)/%.pic
@@ -186,5 +251,5 @@ $(BUILD)/%.sgb.tilemap: %.bin | $$(dir $$@)
 ### Scan .asm files for INCLUDE dependencies
 
 ifeq (,$(filter clean tools,$(MAKECMDGOALS)))
--include $(patsubst %.o, %.d, $(GOLD_OBJS) $(SILVER_OBJS))
+-include $(patsubst %.o, %.d, $(GOLD_OBJS) $(SILVER_OBJS) $(GOLD_DEBUG_OBJS) $(SILVER_DEBUG_OBJS))
 endif

--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@ This is a work-in-progress disassembly of the Pokémon Gold and Pokémon Silver 
 
 It builds the following ROMs:
 
+- Gold_nondebug.sgb (aka MONS2KN.COM) `sha1: 6a5df1b84698168b44ca53b0df15128e4bfaad6a`
+- Gold_nondebug.sgb, with correct header `sha1: 5a0cb44a053c00e7c37f6aa0d0bd8da4e3a3a185`
+- Silver_nondebug.sgb (aka MONS2SN.COM) `sha1: f338dafd76619be268b4987bd2c94adb15aa9386`
+- Silver_nondebug.sgb, with correct header `sha1: 1ea711762d7fad318599904758dabba3d9390c41`
 - Gold_debug.sgb (aka MONS2KD.COM) `sha1: b1d7539a87dea81b2cff6146afaad64470d08d84`
 - Gold_debug.sgb, with correct header `sha1: 87fd8dbe5db39619529abcfc99e74cc5ecb8b94e`
 - Silver_debug.sgb (aka MONS2SD.COM) `sha1: 4c576dd4671bb1fe36c5e6d76c8909f98d739667`
 - Silver_debug.sgb, with correct header `sha1: 51b78133bdb7b80e595014941bda5c20dac05967`
 
-You will need to provide a copy of Gold_debug.sgb renamed **baserom-gold.gb** and a copy of Silver_debug.sgb renamed **baserom-silver.gb** to build the ROMs.
+To build the ROMs, you will need to provide copies of:
+
+- Gold_nondebug.sgb, renamed **baserom-gold.gb**
+- Silver_nondebug.sgb, renamed **baserom-silver.gb**
+- Gold_debug.sgb, renamed **baserom-gold-debug.gb**
+- Silver_debug.sgb, renamed **baserom-silver-debug.gb**
 
 
 ## See also

--- a/data/pokemon/base_stats/kirinriki.inc
+++ b/data/pokemon/base_stats/kirinriki.inc
@@ -6,7 +6,11 @@
 	db TYPE_DARK, TYPE_NORMAL ; type
 	db 255 ; catch rate
 	db 100 ; base exp
+if DEF(_GOLD) & !DEF(_DEBUG)
+	db ITEM_APPLE, ITEM_TAG ; items
+else
 	db ITEM_BERRY, ITEM_TAG ; items
+endc
 	db GENDER_50_50 ; gender ratio
 	db 100, 4, 70 ; unknown
 	dn 7, 7 ; sprite dimensions

--- a/data/pokemon/base_stats/kirinriki.inc
+++ b/data/pokemon/base_stats/kirinriki.inc
@@ -6,7 +6,7 @@
 	db TYPE_DARK, TYPE_NORMAL ; type
 	db 255 ; catch rate
 	db 100 ; base exp
-if DEF(_GOLD) & !DEF(_DEBUG)
+if DEF(_GOLD) && !DEF(_DEBUG)
 	db ITEM_APPLE, ITEM_TAG ; items
 else
 	db ITEM_BERRY, ITEM_TAG ; items

--- a/data/trainers/parties.inc
+++ b/data/trainers/parties.inc
@@ -679,11 +679,4 @@ if DEF(_SILVER)
 	db "たまお@", TRAINERTYPE_ITEM_MOVES
 	db 10, DEX_JIGGLYPUFF, ITEM_NONE, MOVE_CHARM, MOVE_POUND, MOVE_ENCORE, MOVE_NONE
 	db -1 ; end
-
-	db -1 ; end
-
-	; early version of KIMONO_GIRL_KOUME?
-	db "こうめ@", TRAINERTYPE_ITEM_MOVES
-	db  8, DEX_CLEFAIRY, ITEM_NONE
-	db -1 ; end
 endc

--- a/engine/debug/subgame_debug_menu.asm
+++ b/engine/debug/subgame_debug_menu.asm
@@ -71,6 +71,3 @@ SubGameMenu_PicrossGame:
 SubGameMenu_SlotMachineGame:
 	callfar SlotMachineGame
 	ret
-; unreferenced
-	cpl
-	ret

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -24,6 +24,7 @@ PokemonCenterPC:
 ; Open the player's PC menu
 	ld hl, .TurnOnText
 	call MenuTextBoxBackup
+
 if DEF(_DEBUG)
 	ld hl, wDebugFlags
 	bit DEBUG_FIELD_F, [hl]

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -24,6 +24,7 @@ PokemonCenterPC:
 ; Open the player's PC menu
 	ld hl, .TurnOnText
 	call MenuTextBoxBackup
+if DEF(_DEBUG)
 	ld hl, wDebugFlags
 	bit DEBUG_FIELD_F, [hl]
 	jr nz, .DisplayMenu
@@ -35,6 +36,7 @@ PokemonCenterPC:
 	text "<⋯⋯>　が　つながっていなかった"
 	line "ようだ　<⋯⋯>"
 	prompt
+endc
 
 .DisplayMenu:
 	ld hl, .TopMenu

--- a/engine/movie/title.asm
+++ b/engine/movie/title.asm
@@ -421,8 +421,12 @@ TitleSeq_TitleScreenInputAndTimeout::
 	jr .psbtn_nextseq
 
 .psbtn_gotodebug
+if DEF(_DEBUG)
 	ld a, $01 ; DebugMenu
 	jr .psbtn_nextseq
+else
+	ret
+endc
 
 .psbtn_sramclear
 	ld a, $02

--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -13,12 +13,14 @@ UnusedOverworldMovementCheck::
 	jr z, SetPlayerIdle ; player movement is disabled
 	ldh a, [hJoyState]
 	ld d, a
+if DEF(_DEBUG)	
 	ld hl, wDebugFlags
 	bit DEBUG_FIELD_F, [hl]
 	jr z, .skip_debug_move
 	bit B_BUTTON_F, d
 	jp nz, CheckMovementDebug
 .skip_debug_move
+endc
 	ld a, [wPlayerState]
 	cp PLAYER_SKATE
 	jp z, CheckMovementSkateboard
@@ -572,6 +574,7 @@ _OverworldMovementCheck::
 	jp z, SetPlayerIdle
 	ldh a, [hJoyState]
 	ld d, a
+if DEF(_DEBUG)
 	ld hl, wDebugFlags
 	bit DEBUG_FIELD_F, [hl]
 	jr z, .skip_debug_move
@@ -579,6 +582,7 @@ _OverworldMovementCheck::
 	jp nz, CheckMovementDebug
 
 .skip_debug_move
+endc
 	call GetPlayerMovementByState
 	jp SetPlayerMovement
 

--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -13,7 +13,7 @@ UnusedOverworldMovementCheck::
 	jr z, SetPlayerIdle ; player movement is disabled
 	ldh a, [hJoyState]
 	ld d, a
-if DEF(_DEBUG)	
+if DEF(_DEBUG)
 	ld hl, wDebugFlags
 	bit DEBUG_FIELD_F, [hl]
 	jr z, .skip_debug_move
@@ -580,7 +580,6 @@ if DEF(_DEBUG)
 	jr z, .skip_debug_move
 	bit B_BUTTON_F, d
 	jp nz, CheckMovementDebug
-
 .skip_debug_move
 endc
 	call GetPlayerMovementByState

--- a/garbage/garbage.asm
+++ b/garbage/garbage.asm
@@ -3,6 +3,7 @@ INCLUDE "constants.asm"
 SECTION "garbage.asm@Home Garbage", ROM0
 
 if DEF(_DEBUG)
+
 DEF Old_FarCallFunctionAddress EQU $2f91
 
 Unreferenced_Corrupt__InterlaceMergeSpriteBuffers.interlaceLoopFlipped:
@@ -343,6 +344,7 @@ Unused_SpecialMapMusic_Old:
 .normal
 	and a
 	ret
+
 endc
 
 SECTION "garbage.asm@Bank 01 Garbage", ROMX
@@ -372,6 +374,7 @@ endc
 SECTION "garbage.asm@Bank 03 Garbage", ROMX
 
 if DEF(_DEBUG)
+
 if DEF(_GOLD)
 Unreferenced_Corrupt_AlreadyKnowsMoveText1:
 	db "います"
@@ -429,6 +432,7 @@ endc
 if DEF(_SILVER)
 INCBIN "garbage/bank03_silver.2bpp", 35
 endc
+
 endc
 
 
@@ -495,6 +499,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 0b Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0b_gold.2bpp", 111
@@ -506,6 +511,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 0c Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0c_gold.2bpp"
@@ -517,6 +523,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 0d Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0d_gold.2bpp"
@@ -528,6 +535,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 0e Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0e_gold.2bpp", 188
@@ -545,6 +553,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 0f Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0f_gold.2bpp", 75
@@ -556,7 +565,9 @@ endc
 
 
 SECTION "garbage.asm@Bank 10 Garbage", ROMX
+
 if DEF(_DEBUG)
+
 if DEF(_GOLD)
 Unreferenced_Corrupt_LeafyEvosAttacks1:
 	db 0 ; no more evolutions
@@ -633,10 +644,12 @@ if DEF(_SILVER)
 
 INCBIN "garbage/bank10_silver.2bpp"
 endc
+
 endc
 
 
 SECTION "garbage.asm@Bank 14 Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank14_gold.2bpp", 116
@@ -648,6 +661,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 20 Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -660,6 +674,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 22 Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -672,6 +687,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 35 Garbage", ROMX
+
 ; This whole bank is garbage data.
 rept 23
 	ret
@@ -687,6 +703,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 28 Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -699,6 +716,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 29 Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -711,6 +729,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 2a Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -723,6 +742,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 2b Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -735,6 +755,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 2c Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -747,6 +768,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 2d Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -759,6 +781,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 2e Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -771,6 +794,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 31 Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank31_gold.2bpp"
@@ -782,6 +806,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 39 Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank39_gold.2bpp", 159
@@ -793,6 +818,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 3c Garbage", ROMX
+
 if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank3c_gold.2bpp", 78
@@ -804,6 +830,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 3d Garbage", ROMX
+
 ; This whole bank is garbage data.
 if DEF(_DEBUG)
 if DEF(_GOLD)
@@ -816,6 +843,7 @@ endc
 
 
 SECTION "garbage.asm@Bank 3f Garbage", ROMX
+
 if DEF(_DEBUG)
 	cpl
 	ret

--- a/garbage/garbage.asm
+++ b/garbage/garbage.asm
@@ -2,6 +2,7 @@ INCLUDE "constants.asm"
 
 SECTION "garbage.asm@Home Garbage", ROM0
 
+if DEF(_DEBUG)
 DEF Old_FarCallFunctionAddress EQU $2f91
 
 Unreferenced_Corrupt__InterlaceMergeSpriteBuffers.interlaceLoopFlipped:
@@ -342,29 +343,35 @@ Unused_SpecialMapMusic_Old:
 .normal
 	and a
 	ret
+endc
 
 SECTION "garbage.asm@Bank 01 Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 	ds 982, $39, $00
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank01_silver.2bpp", 42
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 02 Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank02_gold.2bpp", 188
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank02_silver.2bpp", 188
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 03 Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 Unreferenced_Corrupt_AlreadyKnowsMoveText1:
 	db "います"
@@ -422,104 +429,134 @@ endc
 if DEF(_SILVER)
 INCBIN "garbage/bank03_silver.2bpp", 35
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 04 Garbage", ROMX
 
+if DEF(_DEBUG)
+	db $18, $00 ; leftover of previous graphics
+Unreferenced_UnusedLeaderNameGFX:: INCBIN "gfx/trainer_card/unused_leader_name.2bpp"
 if DEF(_GOLD)
 INCBIN "garbage/bank04_gold.2bpp", 227
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank04_silver.2bpp", 227
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 05 Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank05_gold.2bpp", 74
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank05_silver.2bpp", 74
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 06 Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank06_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank06_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 09 Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank09_gold.2bpp", 116
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank09_silver.2bpp", 116
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 0a Garbage", ROMX
 
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0a_gold.2bpp", 62
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank0a_silver.2bpp", 62
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 0b Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0b_gold.2bpp", 111
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank0b_silver.2bpp", 111
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 0c Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0c_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank0c_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 0d Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0d_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank0d_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 0e Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0e_gold.2bpp", 188
 endc
 if DEF(_SILVER)
+	db -1 ; end
+
+	; early version of KIMONO_GIRL_KOUME?
+	db "こうめ@", TRAINERTYPE_ITEM_MOVES
+	db  8, DEX_CLEFAIRY, ITEM_NONE
+	db -1 ; end
 INCBIN "garbage/bank0e_silver.2bpp", 185
+endc
 endc
 
 
 SECTION "garbage.asm@Bank 0f Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank0f_gold.2bpp", 75
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank0f_silver.2bpp", 75
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 10 Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 Unreferenced_Corrupt_LeafyEvosAttacks1:
 	db 0 ; no more evolutions
@@ -540,33 +577,6 @@ Unreferenced_Corrupt_LeafyEvosAttacks2:
 	db 56, MOVE_WRAP
 	db 63, MOVE_SOLARBEAM
 	db 0 ; no more level-up moves
-Unreferenced_Corrupt_TailEvosAttacks:
-	db 25, MOVE_SWIFT
-	db 31, MOVE_MUD_SLAP
-	db 38, MOVE_FURY_SWIPES
-	db 45, MOVE_MIMIC
-	db 0 ; no more level-up moves
-Unreferenced_Corrupt_LeafyEvosAttacks3:
-	db 0 ; no more evolutions
-	db  1, MOVE_TACKLE
-	db  7, MOVE_SAND_ATTACK
-	db 14, MOVE_QUICK_ATTACK
-	db 21, MOVE_TAIL_WHIP
-	db 28, MOVE_ABSORB
-	db 35, MOVE_RAZOR_LEAF
-	db 42, MOVE_GROWTH
-	db 49, MOVE_MORNING_SUN
-	db 56, MOVE_WRAP
-	db 63, MOVE_SOLARBEAM
-	db 0 ; no more level-up moves
-Unreferenced_Corrupt_LeafyEvosAttacks4:
-	db 56, MOVE_WRAP
-	db 63, MOVE_SOLARBEAM
-	db 0 ; no more level-up moves
-
-	db $E6, $6D, $C3, $FF ; garbage
-
-INCBIN "garbage/bank10_gold.2bpp"
 endc
 
 if DEF(_SILVER)
@@ -590,6 +600,7 @@ Unreferenced_Corrupt_TailEvosAttacks:
 	db  9, MOVE_SAND_ATTACK
 	db 14, MOVE_PURSUIT
 	db 19, MOVE_ENCORE
+endc
 	db 25, MOVE_SWIFT
 	db 31, MOVE_MUD_SLAP
 	db 38, MOVE_FURY_SWIPES
@@ -612,39 +623,51 @@ Unreferenced_Corrupt_LeafyEvosAttacks4:
 	db 56, MOVE_WRAP
 	db 63, MOVE_SOLARBEAM
 	db 0 ; no more level-up moves
+if DEF(_GOLD)
+	db $E6, $6D, $C3, $FF ; garbage
 
+INCBIN "garbage/bank10_gold.2bpp"
+endc
+if DEF(_SILVER)
 	db 0, 0, 0, 0 ; garbage
 
 INCBIN "garbage/bank10_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 14 Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank14_gold.2bpp", 116
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank14_silver.2bpp", 116
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 20 Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank20_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank20_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 22 Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank22_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank22_silver.2bpp"
+endc
 endc
 
 
@@ -653,125 +676,153 @@ SECTION "garbage.asm@Bank 35 Garbage", ROMX
 rept 23
 	ret
 endr
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank35_gold.2bpp", 23
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank35_silver.2bpp", 23
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 28 Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank28_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank28_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 29 Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank29_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank29_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 2a Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank2a_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank2a_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 2b Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank2b_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank2b_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 2c Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank2c_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank2c_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 2d Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank2d_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank2d_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 2e Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank2e_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank2e_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 31 Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank31_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank31_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 39 Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank39_gold.2bpp", 159
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank39_silver.2bpp", 159
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 3c Garbage", ROMX
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank3c_gold.2bpp", 78
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank3c_silver.2bpp", 78
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 3d Garbage", ROMX
 ; This whole bank is garbage data.
+if DEF(_DEBUG)
 if DEF(_GOLD)
 INCBIN "garbage/bank3d_gold.2bpp"
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank3d_silver.2bpp"
 endc
+endc
 
 
 SECTION "garbage.asm@Bank 3f Garbage", ROMX
+if DEF(_DEBUG)
+	cpl
+	ret
 if DEF(_GOLD)
 INCBIN "garbage/bank3f_gold.2bpp", 45
 endc
 if DEF(_SILVER)
 INCBIN "garbage/bank3f_silver.2bpp", 45
+endc
 endc

--- a/gfx/gfx.asm
+++ b/gfx/gfx.asm
@@ -123,8 +123,6 @@ TrainerCardColonGFX:: INCBIN "gfx/trainer_card/colon.2bpp"
 TrainerCardIDNoGFX:: INCBIN "gfx/trainer_card/id_no.2bpp"
 .End::
 TrainerCardLeadersGFX:: INCBIN "gfx/trainer_card/leaders.2bpp"
-	db $18, $00 ; leftover of previous graphics
-Unreferenced_UnusedLeaderNameGFX:: INCBIN "gfx/trainer_card/unused_leader_name.2bpp"
 
 SECTION "gfx.asm@Bank 6 Tilesets Silent Hill", ROMX
 SilentHill_GFX:

--- a/home/init.asm
+++ b/home/init.asm
@@ -14,10 +14,18 @@ SECTION "home/init.asm@Global check value", ROM0
 ; The ROM has an incorrect global check, so set it here.
 ; It is not corrected by RGBFIX.
 if DEF(_GOLD)
+if DEF(_DEBUG)
 	dw $C621
+else
+	dw $497E
+endc
 endc
 if DEF(_SILVER)
+if DEF(_DEBUG)
 	dw $2FC9
+else
+	dw $7AB1
+endc
 endc
 
 

--- a/home/init.asm
+++ b/home/init.asm
@@ -11,21 +11,21 @@ SECTION "home/init.asm@Entry point", ROM0
 
 
 SECTION "home/init.asm@Global check value", ROM0
-; The ROM has an incorrect global check, so set it here.
-; It is not corrected by RGBFIX.
+; The ROMs have incorrect global checksums, so set them here.
+; RGBFIX only calculates checksums for the "correctheader" ROMs.
 if DEF(_GOLD)
-if DEF(_DEBUG)
-	dw $C621
-else
-	dw $497E
-endc
+	if DEF(_DEBUG)
+		dw $C621
+	else
+		dw $497E
+	endc
 endc
 if DEF(_SILVER)
-if DEF(_DEBUG)
-	dw $2FC9
-else
-	dw $7AB1
-endc
+	if DEF(_DEBUG)
+		dw $2FC9
+	else
+		dw $7AB1
+	endc
 endc
 
 

--- a/home/map.asm
+++ b/home/map.asm
@@ -1672,7 +1672,9 @@ OverworldLoop_07::
 	ret
 
 OverworldLoop_DebugMapViewer::
+if DEF(_DEBUG)
 	callfar DebugMapViewer
+endc
 	ld a, MAPSTATUS_RETURN_TO_MAIN
 	call SetMapStatus
 	ret

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -7,6 +7,7 @@ OverworldStartButtonCheck::
 	ldh a, [hJoyState]
 	bit START_F, a
 	ret z
+if DEF(_DEBUG)
 	and (START | B_BUTTON)
 	cp (START | B_BUTTON)
 	jr nz, .regularMenu
@@ -15,6 +16,7 @@ OverworldStartButtonCheck::
 	ret z              ; debug disabled
 	farcall FieldDebugMenu
 	jr CheckStartmenuSelectHook
+endc
 .regularMenu
 	farcall DisplayStartMenu
 	jr CheckStartmenuSelectHook

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -5,29 +5,29 @@ SECTION "home/overworld.asm@Startmenu and Select Button Check", ROM0
 
 OverworldStartButtonCheck::
 	ldh a, [hJoyState]
-;	bit SELECT_F, a
-;	jr nz, SelectButtonFunction
 	bit START_F, a
 	ret z
 if DEF(_DEBUG)
-	and (START | B_BUTTON)
-	cp (START | B_BUTTON)
+	and START | B_BUTTON
+	cp START | B_BUTTON
 	jr nz, .regularMenu
 	ld a, [wDebugFlags]
 	bit DEBUG_FIELD_F, a
-	ret z              ; debug disabled
+	ret z ; debug disabled
 	farcall FieldDebugMenu
 	jr CheckStartmenuSelectHook
-endc
 .regularMenu
+endc
 	farcall DisplayStartMenu
 	jr CheckStartmenuSelectHook
+
 SelectButtonFunction::
 	callfar CheckRegisteredItem
+	; fallthrough
 CheckStartmenuSelectHook:
 	ldh a, [hStartmenuCloseAndSelectHookEnable]
 	and a
-	ret z          ; hook is disabled
+	ret z ; hook is disabled
 	ld hl, wQueuedScriptAddr
 	ld a, [hli]
 	ld h, [hl]
@@ -36,7 +36,7 @@ CheckStartmenuSelectHook:
 	call FarCall_hl
 	ld hl, hStartmenuCloseAndSelectHookEnable
 	xor a
-	ld [hli], a    ; clear hook enable and ???
+	ld [hli], a ; clear hook enable and ???
 	ld [hl], a
 	dec a
 	ret

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -5,6 +5,8 @@ SECTION "home/overworld.asm@Startmenu and Select Button Check", ROM0
 
 OverworldStartButtonCheck::
 	ldh a, [hJoyState]
+;	bit SELECT_F, a
+;	jr nz, SelectButtonFunction
 	bit START_F, a
 	ret z
 if DEF(_DEBUG)

--- a/home/rst.asm
+++ b/home/rst.asm
@@ -22,10 +22,10 @@ SECTION "home/rst.asm@rst30", ROM0
 	rst $38
 
 SECTION "home/rst.asm@rst38", ROM0
-	; Jumps in the middle of unmapped echo RAM.
-	; Probably used to trigger a breakpoint.
-if DEF(_SILVER) & DEF(_DEBUG)
+if DEF(_SILVER) && DEF(_DEBUG)
 	rst $38
 else
+	; Jumps in the middle of unmapped echo RAM.
+	; Probably used to trigger a breakpoint.
 	jp $F080
 endc

--- a/home/rst.asm
+++ b/home/rst.asm
@@ -24,9 +24,8 @@ SECTION "home/rst.asm@rst30", ROM0
 SECTION "home/rst.asm@rst38", ROM0
 	; Jumps in the middle of unmapped echo RAM.
 	; Probably used to trigger a breakpoint.
-if DEF(_GOLD)
-	jp $F080
-endc
-if DEF(_SILVER)
+if DEF(_SILVER) & DEF(_DEBUG)
 	rst $38
+else
+	jp $F080
 endc

--- a/home/toolgear.asm
+++ b/home/toolgear.asm
@@ -108,7 +108,7 @@ UpdateToolgear::
 	ld bc, SCREEN_WIDTH
 	ld a, '　'
 	call ByteFill
-
+if DEF(_DEBUG)
 	ld hl, wd153
 	bit TOOLGEAR_COORDS_F, [hl]
 	jr z, .debug_show_time
@@ -122,6 +122,7 @@ UpdateToolgear::
 	ld c, 1
 	call .printHex
 	ret
+endc
 
 .debug_show_time
 	ld hl, hRTCHours

--- a/home/toolgear.asm
+++ b/home/toolgear.asm
@@ -108,6 +108,7 @@ UpdateToolgear::
 	ld bc, SCREEN_WIDTH
 	ld a, '　'
 	call ByteFill
+
 if DEF(_DEBUG)
 	ld hl, wd153
 	bit TOOLGEAR_COORDS_F, [hl]

--- a/roms.sha1
+++ b/roms.sha1
@@ -1,4 +1,8 @@
-b1d7539a87dea81b2cff6146afaad64470d08d84 *pokegold-spaceworld.gb
-87fd8dbe5db39619529abcfc99e74cc5ecb8b94e *pokegold-spaceworld-correctheader.gb
-4c576dd4671bb1fe36c5e6d76c8909f98d739667 *pokesilver-spaceworld.gb
-51b78133bdb7b80e595014941bda5c20dac05967 *pokesilver-spaceworld-correctheader.gb
+6a5df1b84698168b44ca53b0df15128e4bfaad6a *pokegold-spaceworld.gb
+5a0cb44a053c00e7c37f6aa0d0bd8da4e3a3a185 *pokegold-spaceworld-correctheader.gb
+f338dafd76619be268b4987bd2c94adb15aa9386 *pokesilver-spaceworld.gb
+1ea711762d7fad318599904758dabba3d9390c41 *pokesilver-spaceworld-correctheader.gb
+b1d7539a87dea81b2cff6146afaad64470d08d84 *pokegold-spaceworld-debug.gb
+87fd8dbe5db39619529abcfc99e74cc5ecb8b94e *pokegold-spaceworld-debug-correctheader.gb
+4c576dd4671bb1fe36c5e6d76c8909f98d739667 *pokesilver-spaceworld-debug.gb
+51b78133bdb7b80e595014941bda5c20dac05967 *pokesilver-spaceworld-debug-correctheader.gb


### PR DESCRIPTION
Builds matching non-debug roms.
Debug roms now use the -debug suffix, including the baseroms, so the automatic build is invalid.

Verified Correct Build with updated baseroms.
<img width="964" height="495" alt="image" src="https://github.com/user-attachments/assets/f23ced51-c55f-4bac-8caf-28d1b2c08bb2" />
