### PR TITLE
Name functions with exact `pokegold` and `pokered` equivalents

### DIFF
--- a/engine/menu/set_time.asm
+++ b/engine/menu/set_time.asm
@@ -68,8 +68,8 @@ AdjustTimeText:
 	call PrintText
 	jp .loop
 .set_time
-	call Function04ac
-	call Function0502
+	call SetClock
+	call StartRTC
 	jp TextAsmEnd
 
 AdjustTimeEndText:

--- a/engine/movie/oak_speech.asm
+++ b/engine/movie/oak_speech.asm
@@ -70,7 +70,7 @@ GameStart::
 	ld hl, OakSpeech6
 	call PrintText
 	farcall SetClockDialog
-	call Function04ac
+	call SetClock
 	call GBFadeOutToWhite
 	call ClearTileMap
 	ld de, ProtagonistPic
@@ -118,7 +118,7 @@ IntroCleanup::
 	call DelayFrames
 	call GBFadeOutToWhite
 	call ClearTileMap
-	call Function0502
+	call StartRTC
 	ld a, MAPSTATUS_MAIN
 	ld [wLastMapStatus], a
 	ld [wMapStatus], a

--- a/home/fade.asm
+++ b/home/fade.asm
@@ -2,7 +2,9 @@ INCLUDE "constants.asm"
 
 SECTION "home/fade.asm", ROM0
 
-Function0343::
+; Functions to fade the screen in and out.
+
+TimeOfDayFade::
 	ld a, [wTimeOfDayPal] ; tells if current map is dark
 	ld b, a
 	ld hl, FadePal4

--- a/home/time.asm
+++ b/home/time.asm
@@ -91,38 +91,48 @@ UpdateTime::
 	db 50, DARKNESS_F
 	db 59, MORN_F
 
-Function04ac::
+SetClock::
+; set clock data from hram
+
 	ld hl, hRTCStatusFlags
 	set 0, [hl]
-	call Function04ea
+	call StopRTC
+; enable clock r/w
 	ld a, SRAM_ENABLE
 	ld [MBC3SRamEnable], a
+; set clock data
+; stored 'backwards' in hram
 	call LatchClock
 
+; seconds
 	ld a, RTC_S
 	ld [MBC3SRamBank], a
 	ld a, 0
 	ld [MBC3RTC], a
 
+; minutes
 	ld a, RTC_M
 	ld [MBC3SRamBank], a
 	ld a, [wStartMinute]
 	ld [MBC3RTC], a
 
+; hours
 	ld a, RTC_H
 	ld [MBC3SRamBank], a
 	ld a, [wStartHour]
 	ld [MBC3RTC], a
 
+; days
 	ld a, [wStartDay]
 	ldh [hRTCDays], a
 
+; cleanup
 	call CloseSRAM
 	ld hl, hRTCStatusFlags
 	res 0, [hl]
 	ret
 
-Function04ea::
+StopRTC:: ; unreferenced
 	ld a, SRAM_ENABLE
 	ld [MBC3SRamEnable], a
 	call LatchClock
@@ -134,7 +144,7 @@ Function04ea::
 	call CloseSRAM
 	ret
 
-Function0502::
+StartRTC::
 	ld a, SRAM_ENABLE
 	ld [MBC3SRamEnable], a
 	call LatchClock

--- a/home/util.asm
+++ b/home/util.asm
@@ -2,7 +2,8 @@ INCLUDE "constants.asm"
 
 SECTION "home/util.asm", ROM0
 
-Function33ef::
+Copy2x2TilesToVRAM:: ; unreferenced
+; Copies a 2D rectangle from hl (src) to de (dst) with size in (b = y, c = x).
 	; hl = src
 	; de  = dest
 	; b = y
@@ -14,10 +15,10 @@ Function33ef::
 	dec a
 	dec a
 	ld b, $0
-.asm_33f7:
+.row_offset
 	add hl, bc
 	dec a
-	jr nz, .asm_33f7
+	jr nz, .row_offset
 	pop bc
 	dec b
 	ld a, b
@@ -26,7 +27,7 @@ Function33ef::
 	ld d, h
 	ld e, l
 	pop hl
-.asm_3403:
+.col_loop
 	push af
 	push bc
 	call CopyBytes
@@ -44,7 +45,7 @@ Function33ef::
 	pop bc
 	pop af
 	dec a
-	jr nz, .asm_3403
+	jr nz, .col_loop
 	pop hl
 	pop de
 	jp CopyBytes
@@ -83,34 +84,40 @@ CompareBytes::
 	jr nz, .loop
 	ret
 
-Function3439::
+; INPUT:
+; a = oam block index (each block is 4 oam entries)
+; b = Y coordinate of upper left corner of sprite
+; c = X coordinate of upper left corner of sprite
+; de = base address of 4 tile number and attribute pairs
+WriteOAMBlock::
 ; Place 2x2 sprite from *de into OAM at slot a
 	ld h, HIGH(wShadowOAM)
-	swap a
+	swap a ; multiply by 16
 	ld l, a
-	call .Load
+	call .Load ; upper left
 	push bc
 	ld a, $8
 	add c
 	ld c, a
-	call .Load
+	call .Load ; upper right
 	pop bc
 	ld a, $8
 	add b
 	ld b, a
-	call .Load
+	call .Load ; lower left
 	ld a, $8
 	add c
 	ld c, a
+	                      ; lower right
 .Load:
-	ld [hl], b
+	ld [hl], b ; Y coordinate
 	inc hl
-	ld [hl], c
+	ld [hl], c ; X coordinate
 	inc hl
-	ld a, [de]
+	ld a, [de] ; tile number
 	inc de
 	ld [hli], a
-	ld a, [de]
+	ld a, [de] ; attribute
 	inc de
 	ld [hli], a
 	ret


### PR DESCRIPTION
- TimeOfDayFade (`pokegold/home/fade.asm`) (unreferenced in `pokegold`)
- SetClock (`pokegold/home/time.asm`)
- StopRTC, StartRTC (`pokegold/engine/rtc/rtc.asm`)
- WriteOAMBlock (`pokered/home/oam.asm`)

Update call sites in oak_speech.asm and set_time.asm accordingly.