### PR TITLE
Remove some hardcoded addresses, update `PrintNumber` flags

### DIFF
--- a/constants/text_constants.asm
+++ b/constants/text_constants.asm
@@ -30,7 +30,7 @@ DEF TEXTBOX_INNERX EQU TEXTBOX_X + 1
 DEF TEXTBOX_Y      EQU SCREEN_HEIGHT - TEXTBOX_HEIGHT
 DEF TEXTBOX_INNERY EQU TEXTBOX_Y + 2
 
-; PrintNumber bit flags (see home/print_num.asm)
+; PrintNumber, PrintBCDNumber bit flags (see home/print_num.asm and home/print_bcd.asm)
 	const_def 6
 	shift_const PRINTNUM_LEFTALIGN    ; 6
 	shift_const PRINTNUM_LEADINGZEROS ; 7

--- a/constants/text_constants.asm
+++ b/constants/text_constants.asm
@@ -30,16 +30,10 @@ DEF TEXTBOX_INNERX EQU TEXTBOX_X + 1
 DEF TEXTBOX_Y      EQU SCREEN_HEIGHT - TEXTBOX_HEIGHT
 DEF TEXTBOX_INNERY EQU TEXTBOX_Y + 2
 
-; PrintNum bit flags
-	const_def 5
-	const PRINTNUM_MONEY_F        ; 5
-	const PRINTNUM_RIGHTALIGN_F   ; 6
-	const PRINTNUM_LEADINGZEROS_F ; 7
-
-; PrintNum arguments (see engine/math/print_num.asm)
-DEF PRINTNUM_MONEY          EQU 1 << PRINTNUM_MONEY_F
-DEF PRINTNUM_RIGHTALIGN     EQU 1 << PRINTNUM_RIGHTALIGN_F
-DEF PRINTNUM_LEADINGZEROS   EQU 1 << PRINTNUM_LEADINGZEROS_F
+; PrintNumber bit flags (see home/print_num.asm)
+	const_def 6
+	shift_const PRINTNUM_LEFTALIGN    ; 6
+	shift_const PRINTNUM_LEADINGZEROS ; 7
 
 ; character sets (see constants/charmap.asm)
 DEF FIRST_REGULAR_TEXT_CHAR EQU $60

--- a/engine/debug/field/map_viewer.asm
+++ b/engine/debug/field/map_viewer.asm
@@ -410,7 +410,7 @@ DisplayBGEventDetails:
 
 	hlcoord 17, 14
 	ld de, wFieldMoveScriptID
-	ld bc, $8102
+	lb bc, PRINTNUM_LEADINGZEROS | 1, 2
 	call PrintNumber
 
 	hlcoord 14, 16
@@ -419,7 +419,7 @@ DisplayBGEventDetails:
 
 	hlcoord 17, 16
 	ld de, wHPBarNewHP
-	ld bc, $8102
+	lb bc, PRINTNUM_LEADINGZEROS | 1, 2
 	call PrintNumber
 
 	ret

--- a/engine/debug/field/pokemart_menu.asm
+++ b/engine/debug/field/pokemart_menu.asm
@@ -76,7 +76,7 @@ DebugMart_BuyMenuHeader:
 	ld d, h
 	ld e, l
 	pop hl
-	ld c, $83
+	ld c, 3 | PRINTNUM_LEADINGZEROS
 	call PrintBCDNumber
 	ld [hl], '円'
 	ret

--- a/engine/debug/field/sprite_viewer.asm
+++ b/engine/debug/field/sprite_viewer.asm
@@ -150,7 +150,7 @@ FieldDebug_SpriteViewer:
 .display_loop
 	push bc
 	push hl
-	ld bc, $8103
+	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	ld de, wStringBuffer1
 	call PrintNumber
 	ld a, [wStringBuffer1]

--- a/engine/games/poker_minigame.asm
+++ b/engine/games/poker_minigame.asm
@@ -1181,7 +1181,7 @@ PokerMinigame_Shuffling:
 	jr .SetSub
 
 PokerMinigame_ChangeCursor:
-	ld de, $6818
+	depixel 13, 3
 	ld a, SPRITE_ANIM_OBJ_POKER_CURSOR
 	call InitSpriteAnimStruct
 	ld a, c
@@ -1234,7 +1234,7 @@ PokerMinigame_GetMatchText:
 	ld e, [hl]
 	inc hl
 	ld d, [hl]
-	ld hl, $C3B9
+	hlcoord 1, 14
 	call PlaceString
 	ret
 

--- a/engine/items/inventory.asm
+++ b/engine/items/inventory.asm
@@ -8,7 +8,7 @@ Unreferenced_ReceiveItem_Old:
 	push hl
 	ld d, 50 ; PC_ITEM_CAPACITY
 	push hl
-	ld bc, $2e62 ; TODO: ???
+	ld bc, -wNumBagItems
 	add hl, bc
 	ld a, h
 	or l

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -635,7 +635,7 @@ Link_PrepPartyData_Gen1:
 	push bc
 	ld b, $00
 	ld c, a
-	ld hl, $4CD7
+	ld hl, KantoMonSpecials
 	add hl, bc
 	ld a, [hl]
 	ld [wMonHBaseSpecialAtt], a
@@ -1079,8 +1079,8 @@ LinkTrade_TradeStatsMenu:
 	call PlaceString
 
 .joy_loop:
-	ld a, $7F
-	ld [$C3eb], a
+	ld a, '　'
+	ldcoord_a 11, 16
 	ld a, $13
 	ld [wMenuJoypadFilter], a
 	ld a, $01

--- a/engine/menu/menu_2.asm
+++ b/engine/menu/menu_2.asm
@@ -152,7 +152,7 @@ Unreferenced_PlaceMoneyTextbox_Old::
 	ld de, SCREEN_WIDTH + 1
 	add hl, de
 	ld de, wMoney
-	lb bc, PRINTNUM_RIGHTALIGN | 3, 6
+	lb bc, PRINTNUM_LEFTALIGN | 3, 6
 	call PrintNumber
 	ret
 
@@ -185,7 +185,7 @@ PlaceMoneyTextbox:
 	ld de, SCREEN_WIDTH + 1
 	add hl, de
 	ld de, wMoney
-	lb bc, PRINTNUM_RIGHTALIGN | 3, 6
+	lb bc, PRINTNUM_LEFTALIGN | 3, 6
 	call PrintNumber
 	ld [hl], '円'
 	ret

--- a/engine/menu/set_clock_dialog.asm
+++ b/engine/menu/set_clock_dialog.asm
@@ -317,7 +317,7 @@ SetClockDialog_PrintDayOfWeek:
 
 SetClockDialog_PrintNumber:
 	push hl
-	ld a, $7f
+	ld a, '　'
 	ld [hli], a
 	ld [hl], a
 	pop hl

--- a/engine/movie/trade_animation.asm
+++ b/engine/movie/trade_animation.asm
@@ -169,7 +169,7 @@ RunTradeAnimScript:
 	ld de, vChars0
 	call TradeAnim_GetFrontpic
 	ld a, [wOTTrademonSpecies]
-	ld de, $8310
+	ld de, vChars0 tile $31
 	call TradeAnim_GetFrontpic
 	ld a, [wPlayerTrademonSpecies]
 	ld de, wPlayerTrademonSpeciesName
@@ -1186,9 +1186,9 @@ LoadTradeBallAndCableGFX:
 LoadTradeBubbleGFX:
 	ld e, MONICON_TRADE
 	callfar LoadMenuMonIcon
-	ld de, $5991
+	ld de, TradeBubbleGFX
 	ld hl, vChars0 tile $72
-	ld bc, $0a04
+	lb bc, BANK(TradeBubbleGFX), 4
 	call Request2bpp
 	ld a, $08
 	ld hl, wSpriteAnimDict

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -701,7 +701,7 @@ Pokedex_PrintListing:
 	jr z, .unidentified
 
 	ld de, wTempByteValue
-	lb bc, (%10000000 | 1), 3
+	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNumber
 
 ; Here, only seen Pokémon are listed in the first place, so this effectively does nothing.

--- a/engine/pokedex/pokedex_2.asm
+++ b/engine/pokedex/pokedex_2.asm
@@ -842,7 +842,7 @@ PrintUnownListEntry:
 	ld l, c
 	ld h, b
 	ld de, wDexCurUnownIndex
-	lb bc, 1 | %10000000, 2
+	lb bc, PRINTNUM_LEADINGZEROS | 1, 2
 	call PrintNumber
 	ret
 

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -103,7 +103,7 @@ LoadPinkPage::
 	inc hl
 
 	ld de, wMoveGrammar
-	ld bc, $8103
+	lb bc, PRINTNUM_LEADINGZEROS | 1, 3
 	call PrintNumber
 	hlcoord 1, 8
 	call PrintLevel
@@ -212,13 +212,13 @@ LoadPinkPage::
 	ld [wTempMonLevel], a
 	ld de, wTempMonExp
 	hlcoord 12, 11
-	ld bc, $0307
+	lb bc, 3, 7
 	call PrintNumber
 
 	call .CalcExpToNextLevel
 	ld de, wExpToNextLevel
 	hlcoord 10, 13
-	ld bc, $0307
+	lb bc, 3, 7
 	call PrintNumber
 
 	hlcoord 9, 13
@@ -390,7 +390,7 @@ LoadBluePage::
 
 	hlcoord 12, 1
 	ld de, wTempMonID
-	ld bc, $8205
+	lb bc, PRINTNUM_LEADINGZEROS | 2, 5
 	call PrintNumber
 
 	ld hl, .OTPointers

--- a/engine/sprite_anims/core.asm
+++ b/engine/sprite_anims/core.asm
@@ -188,7 +188,7 @@ UpdateAnimFrame::
 	ld h, [hl]
 	ld l, a
 	push bc
-	ld a, [wCurSpriteOAMAddr] ; wCurSpriteOAMAddr = $C4BD
+	ld a, [wCurSpriteOAMAddr]
 	ld e, a
 	ld d, HIGH(wShadowOAM)
 	ld a, [hli]
@@ -287,7 +287,7 @@ AddOrSubtractX:
 	ret
 
 GetSpriteOAMAttr:
-	ld a, [wSpriteAnimAddrBackup] ; wSpriteAnimAddrBackup = $C4C0
+	ld a, [wSpriteAnimAddrBackup]
 	ld b, a
 	ld a, [hl]
 	xor b

--- a/engine/tilesets/timeofday_pals.asm
+++ b/engine/tilesets/timeofday_pals.asm
@@ -68,7 +68,7 @@ OverworldFadeOut::
 
 ReplaceTimeOfDayPals::
 	ld hl, TimeOfDayPalsets
-	ld a, [wMapPermissions] ; wMapPermissions = $D661
+	ld a, [wMapPermissions]
 	cp TOWN
 	jr z, .get_palset
 

--- a/home/cry.asm
+++ b/home/cry.asm
@@ -88,7 +88,7 @@ PrintLevelFullWidth::
 _PrintLevelCommon:
 	ld [wTempSpecies], a
 	ld de, wTempSpecies
-	ld b, PRINTNUM_RIGHTALIGN | 1
+	ld b, PRINTNUM_LEFTALIGN | 1
 	jp PrintNumber
 
 GetNthMove:: ; unreferenced?

--- a/home/names.asm
+++ b/home/names.asm
@@ -1,13 +1,15 @@
 NamesPointers::
 ; entries correspond to GetName constants (see constants/text_constants.asm)
-	dba PokemonNames       ; MON_NAME (not used; jumps to GetPokemonName)
-	dba MoveNames          ; MOVE_NAME
-	dbw 0, 0               ; DUMMY_NAME
-	dba ItemNames          ; ITEM_NAME
-	dbw $00, wPartyMonOTs  ; PARTY_OT_NAME
-	dbw $00, wOTPartyMonOT ; ENEMY_OT_NAME
-	dba TrainerClassNames  ; TRAINER_NAME
-	dbw $04, $5677         ; MOVE_DESC_NAME_BROKEN (wrong bank..?)
+	table_width 3
+	dba PokemonNames        ; MON_NAME (not used; jumps to GetPokemonName)
+	dba MoveNames           ; MOVE_NAME
+	dba NULL                ; DUMMY_NAME
+	dba ItemNames           ; ITEM_NAME
+	dbw 0, wPartyMonOTs     ; PARTY_OT_NAME
+	dbw 0, wOTPartyMonOT    ; ENEMY_OT_NAME
+	dba TrainerClassNames   ; TRAINER_NAME
+	dbw 4, MoveDescriptions ; MOVE_DESC_NAME_BROKEN (wrong bank)
+	assert_table_length NUM_NAME_TYPES
 
 GetName::
 ; Return name wCurSpecies from name list wNamedObjectTypeBuffer in wStringBuffer1.

--- a/home/print_bcd.asm
+++ b/home/print_bcd.asm
@@ -7,12 +7,12 @@
 ; bit 6: if set, left-align the string (do not pad empty digits with spaces)
 ;        if unset, right-align the string
 ; bits 0-5: length of BCD number in bytes
-; Note that bits 5 and 7 are modified during execution. The above reflects
-; their meaning at the beginning of the functions's execution.
+; Note that bit 7 is modified during execution. The above reflects
+; its meaning at the beginning of the functions's execution.
 PrintBCDNumber::
-	ld b, c  ; save flags in b
-	res 7, c
-	res 6, c ; c now holds the length
+	ld b, c                        ; save flags in b
+	res PRINTNUM_LEADINGZEROS_F, c
+	res PRINTNUM_LEFTALIGN_F, c    ; c now holds the length
 .loop
 	ld a, [de]
 	swap a
@@ -22,13 +22,13 @@ PrintBCDNumber::
 	inc de
 	dec c
 	jr nz, .loop
-	bit 7, b      ; were any non-zero digits printed?
+	bit PRINTNUM_LEADINGZEROS_F, b ; were any non-zero digits printed?
 	jr z, .done
-.numberEqualsZero ; if every digit of the BCD number is zero
-	bit 6, b
+.numberEqualsZero                  ; if every digit of the BCD number is zero
+	bit PRINTNUM_LEFTALIGN_F, b
 	jr nz, .skipRightAlignmentAdjustment
-	dec hl                    ; if the string is right-aligned, it needs
-.skipRightAlignmentAdjustment ;to be moved back one space
+	dec hl                         ; if the string is right-aligned, it needs
+.skipRightAlignmentAdjustment      ; to be moved back one space
 	ld [hl], '０'
 	call PrintLetterDelay
 	inc hl
@@ -39,16 +39,16 @@ PrintBCDDigit::
 	and $0f
 	and a
 	jr z, .zeroDigit
-	res 7, b           ; unset 7 to indicate that a nonzero
-.outputDigit           ; digit has been reached
+	res PRINTNUM_LEADINGZEROS_F, b ; unset PRINTNUM_LEADINGZEROS_F to indicate
+.outputDigit                       ; that a nonzero digit has been reached
 	add '０'
 	ld [hli], a
 	jp PrintLetterDelay
 .zeroDigit
-	bit 7, b           ; either printing leading zeroes or
-	jr z, .outputDigit ; already reached a nonzero digit?
-	bit 6, b
-	ret nz             ; left-align, don't pad with space
+	bit PRINTNUM_LEADINGZEROS_F, b ; either printing leading zeroes or
+	jr z, .outputDigit             ; already reached a nonzero digit?
+	bit PRINTNUM_LEFTALIGN_F, b
+	ret nz                         ; left-align, don't pad with space
 	ld a, '　'
 	ld [hli], a
 	ret

--- a/home/print_num.asm
+++ b/home/print_num.asm
@@ -224,7 +224,7 @@ PrintNumber::
 	ret
 .PrintLeadingZero:
 ; prints a leading zero unless they are turned off in the flags
-	bit 7, d
+	bit PRINTNUM_LEADINGZEROS_F, d
 	ret z
 	ld [hl], '０'
 	ret
@@ -232,13 +232,13 @@ PrintNumber::
 .AdvancePointer:
 ; increments the pointer unless leading zeroes are not being printed,
 ; the number is left-aligned, and no nonzero digits have been printed yet
-	bit 7, d      ; print leading zeroes?
+	bit PRINTNUM_LEADINGZEROS_F, d
 	jr nz, .inc
-	bit 6, d      ; left alignment or right alignment?
+	bit PRINTNUM_LEFTALIGN_F, d
 	jr z, .inc
 	ldh a, [hPrintNumLeadingDigit]
 	and a
-	ret z         ; don't advance if leading digit is zero
+	ret z ; don't advance if leading digit is zero
 .inc
 	inc hl
 	ret

--- a/home/text.asm
+++ b/home/text.asm
@@ -588,7 +588,7 @@ Text_TX_NUM::
 	ld a, b
 	and $f0
 	swap a
-	set 6, a
+	set PRINTNUM_LEFTALIGN_F, a
 	ld b, a
 	call PrintNumber
 	ld b, h
@@ -630,11 +630,11 @@ Text_PlaySound::
 	inc hl
 	jr .loop
 .found
-	cp $14
+	cp TX_CRY_14
 	jr z, .playCry
-	cp $15
+	cp TX_CRY_15
 	jr z, .playCry
-	cp $16
+	cp TX_CRY_16
 	jr z, .playCry
 	push de
 	ld e, [hl]

--- a/scripts/Route1P2.asm
+++ b/scripts/Route1P2.asm
@@ -48,7 +48,7 @@ Route1P2Text1:
 	jp Init
 
 Route1P2Text2:
-	ld hl, wRoute1P2Flags ; trainer flags?
+	ld hl, wRoute1P2Flags
 	bit 1, [hl]
 	jr nz, .Text2Jump ; already fought
 	ld hl, Route1P2TextString1

--- a/scripts/Route1P2.asm
+++ b/scripts/Route1P2.asm
@@ -48,12 +48,12 @@ Route1P2Text1:
 	jp Init
 
 Route1P2Text2:
-	ld hl, $D3A2 ; trainer flags?
+	ld hl, wRoute1P2Flags ; trainer flags?
 	bit 1, [hl]
 	jr nz, .Text2Jump ; already fought
 	ld hl, Route1P2TextString1
 	call OpenTextbox
-	ld hl, $D3A2
+	ld hl, wRoute1P2Flags
 	set 1, [hl]
 	ld a, TRAINER_KIMONO_GIRL
 	ld [wOtherTrainerClass], a

--- a/scripts/SilentHills.asm
+++ b/scripts/SilentHills.asm
@@ -41,7 +41,7 @@ SilentHillsText1:
 	ret
 
 SilentHillsTrainer2:
-	ld hl, $D3A5
+	ld hl, wSilentHillsFlags
 	bit 1, [hl]
 	jr nz, .Trainer2Won
 	ld hl, SilentHillsTrainer2EncounterString


### PR DESCRIPTION
As far as I can tell, the only remaining raw addresses are in `engine/overworld/player_animations_old.asm` and `garbage/garbage.asm`.
I updated the flags in `PrintNumber` with the conventions from pokegold. `PRINTNUM_MONEY` isn't supported so it has been removed.